### PR TITLE
V. 1.2 update; buff system, item fuzzing, item additions + more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+savegame


### PR DESCRIPTION
Changelog:
- added a new buff system; Fighter class now has 5 new parameters.  power_buff, defense_buff and hp_buff are buff values for power, defense and hp respectively, and are added to stats calculation. buff_type provides the type of buff the fighter object currently has, or None if the object is not buffed.
- two new buff_types introduced: 'shield' buff types lose buff_charge when the buffed object is attacked, while 'aura' buff types lose buff_charge when the object moves. In both cases the buff is removed when buff_charge for that object hits zero.
-update_buff function is called after each attack and move action by  both the player and other NPCS to keep track of buff statuses
-added a feature where the name of an item that has not been picked up is '??' when the mouse is hovered over it.  The name of the item is revealed if the item is picked up and then dropped. Applies only to spells and equipment
-added scroll of Oakskin spell, which leverages new buff system; provides a shield aura that increases the player's defense by 2. Lasts for 5 charges(5 hits from an enemy NPC)
- added helmet equipment item; spawns at lower level then shield, increases defense by 1 hwne equipped. equipped in the head slot
-added prompt that tells the player to press X when standing on the stairs
-minor grammar changes + QOL improvements